### PR TITLE
ci: update outdated GitHub Actions and add github-actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,14 +19,14 @@ jobs:
         language: [ 'python' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt install libsasl2-dev python3-dev libldap2-dev libssl-dev
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
       # Run open source static analysis tools
     - name: Run OSSAR
@@ -26,6 +26,6 @@ jobs:
 
       # Upload results to the Security tab
     - name: Upload OSSAR results
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -32,10 +32,10 @@ jobs:
           - ubuntu-24.04
           - ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -43,8 +43,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           sudo apt install libsasl2-dev libldap2-dev libssl-dev upx
-      - if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: sudo apt install python3-dev
       - name: Compile binary
         run: ./pyinstaller.sh
       - name: Upload binaries to release


### PR DESCRIPTION
Several GitHub Actions used in CI workflows were pinned to outdated or deprecated major versions. This updates them to current versions and adds the `github-actions` ecosystem to Dependabot so action versions stay current going forward.

Notable changes:
- `actions/checkout` v2 -> v4 and `actions/setup-python` v2 -> v5 across all workflows
- `github/codeql-action/*` v1 -> v3 (v1 is deprecated and no longer receiving updates)
- `github/codeql-action/upload-sarif` v1 -> v3 in ossar-analysis.yml
- Removed dead `if: matrix.os == 'ubuntu-18.04'` conditional in publish.yml (ubuntu-18.04 is not in the matrix)
- `github/ossar-action` kept at v1 since there is no stable v2 branch
- Added `github-actions` package ecosystem to `.github/dependabot.yml`