### PR TITLE
fix: update outdated tox example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ tox
 To run a specific Python-OpenVPN combination run something like
 
 ```shell
-tox -e python38-openvpn25
+tox -e python312-openvpn26
 ```
 
 To see a full list of current environment see the `tool.tox` section in [pyproject.toml](pyproject.toml).


### PR DESCRIPTION
The tox example in the README referenced `python38-openvpn25`, which no longer exists in the tox envlist. Updated to `python312-openvpn26` to match the current configuration in `pyproject.toml`.