### PR TITLE
fix: correct VERB to verb in test environment mock

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -93,7 +93,7 @@ def test_load_script(connection: SimpleLDAPObject, config_c_plugin, openvpn_serv
 
 
 @pytest.mark.parametrize("config", [CONFIG_CHALLENGE_RESPONSE_APPEND], indirect=True)
-@mock.patch.dict(os.environ, {'VERB': '11', 'username': TEST_USERNAME, 'password': TEST_USER_PASSWORD})
+@mock.patch.dict(os.environ, {'verb': '11', 'username': TEST_USERNAME, 'password': TEST_USER_PASSWORD})
 def test_profile(config: dict, benchmark_result_file: str):
     profile_path = os.path.join(os.path.dirname(benchmark_result_file), 'profile.prof')
     cProfile.runctx('main()', globals(), locals(), filename=profile_path)


### PR DESCRIPTION
The test_profile test in test_load.py sets VERB (uppercase) in the mock environment, but main.py reads the verbosity from verb (lowercase, matching what OpenVPN passes). Since environment variable lookups are case-sensitive on Linux, the mock had no effect and the test always ran with the default verbosity level of 1 instead of the intended 11.