### PR TITLE
fix: replace deprecated logging.WARN and add exception chaining

### DIFF
--- a/openvpn_ldap_auth/main.py
+++ b/openvpn_ldap_auth/main.py
@@ -29,7 +29,7 @@ def setup_logging(verbosity: int):
     elif verbosity == 3:
         level = logging.INFO
     else:
-        level = logging.WARN
+        level = logging.WARNING
     logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=level)
 
 
@@ -211,10 +211,10 @@ class LDAPAuthenticator:
         con.set_option(ldap.OPT_TIMEOUT, self._timeout)
         try:
             con.simple_bind_s(bind_dn, password)
-        except ldap.INVALID_CREDENTIALS:
-            raise LDAPException(f"Invalid password for {bind_dn}")
+        except ldap.INVALID_CREDENTIALS as e:
+            raise LDAPException(f"Invalid password for {bind_dn}") from e
         except ldap.LDAPError as e:
-            raise LDAPException(f"Simple bind failed for {bind_dn}: {e}")
+            raise LDAPException(f"Simple bind failed for {bind_dn}: {e}") from e
         return con
 
     def _find_user(self, username):


### PR DESCRIPTION
\`logging.WARN\` is an undocumented alias for \`logging.WARNING\` that has been deprecated since Python 3.12 and may be removed in a future version. This replaces it with the documented \`logging.WARNING\` constant.

Additionally, two \`raise\` statements in \`_establish_ldap_connection\` now use proper exception chaining (\`raise ... from e\`) so the original LDAP error traceback is preserved when the exception is re-raised as \`LDAPException\`. This helps with debugging authentication failures.