### PR TITLE
chore: migrate from docker-compose V1 to docker compose V2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,16 +61,16 @@ setenv =
     python313: python_version=3.13
     openvpn26: openvpn_version=2.6
 allowlist_externals =
-    docker-compose
+    docker
     bash
 commands_pre:
-    docker-compose -f tests/resources/docker/docker-compose.yml up -d --build
-    docker-compose -f tests/resources/docker/docker-compose.yml run openvpn bash -c 'openvpn --version || true'
+    docker compose -f tests/resources/docker/docker-compose.yml up -d --build
+    docker compose -f tests/resources/docker/docker-compose.yml run openvpn bash -c 'openvpn --version || true'
 commands =
-    docker-compose -f tests/resources/docker/docker-compose.yml run openvpn bash -c 'poetry install && poetry build && ./pyinstaller.sh && mv dist/openvpn-ldap-auth /usr/bin/openvpn-ldap-auth-pyinstaller && pip install --upgrade dist/*.whl && poetry run pytest {posargs}'
+    docker compose -f tests/resources/docker/docker-compose.yml run openvpn bash -c 'poetry install && poetry build && ./pyinstaller.sh && mv dist/openvpn-ldap-auth /usr/bin/openvpn-ldap-auth-pyinstaller && pip install --upgrade dist/*.whl && poetry run pytest {posargs}'
 commands_post:
-    bash -c "docker-compose -f tests/resources/docker/docker-compose.yml run openvpn chown -R $UID /project"
-    docker-compose -f tests/resources/docker/docker-compose.yml down
+    bash -c "docker compose -f tests/resources/docker/docker-compose.yml run openvpn chown -R $UID /project"
+    docker compose -f tests/resources/docker/docker-compose.yml down
 """
 
 [build-system]

--- a/tests/resources/docker/docker-compose.yml
+++ b/tests/resources/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   openvpn:
     container_name: "openvpn-${python_version}-${openvpn_version}"


### PR DESCRIPTION
The standalone `docker-compose` (V1) command has been deprecated since July 2023 and removed from newer Docker installations. This migrates all tox invocations to the `docker compose` (V2) plugin syntax and drops the obsolete `version` key from `docker-compose.yml`.

Note: `.github/workflows/test.yml` also installs the legacy `docker-compose` package via apt, which is no longer needed since GitHub Actions runners already include Docker Compose V2. That change could not be included here due to token scope limitations but should be applied separately (remove the `sudo apt-get install -y docker-compose` line).